### PR TITLE
Added issue template for Server projects server-template-update.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/server-template-update.md
+++ b/.github/ISSUE_TEMPLATE/server-template-update.md
@@ -1,0 +1,37 @@
+---
+name: Server Template Update
+about: A checklist of servers to consider this update for
+title: Server Template Update
+labels: cherry-pick
+assignees: ''
+---
+---
+Please create an issue for every bugfix / feature update to the clinical-trial-parse-server-template repository and fill out below.
+
+---
+
+Approved template PR Link:
+
+--- 
+Squash and merged commit in template: 
+
+---
+
+Determine which repositories need this update. Edit in links to PRs that cherry-pick this update into their respective repository. Only check off servers that have had this update merged their develop branch.
+
+- [ ] [mgh-psp-server](https://github.com/biosensics/mgh-psp-server)
+- [ ] [nili-parse-server](https://github.com/biosensics/nili-parse-server)
+- [ ] [regeneron-parse-server](https://github.com/biosensics/regeneron-parse-server)
+- [ ] [biodigit-mobile-parse-server](https://github.com/biosensics/biodigit-mobile-parse-server)
+- [ ] [lundbeck-msa-18221A-server](https://github.com/biosensics/lundbeck-msa-18221A-server)
+- [ ] [clinical-trial-parse-server-als](https://github.com/biosensics/clinical-trial-parse-server-als)
+- [ ] [ctra-parse-server](https://github.com/biosensics/ctra-parse-server)
+- [ ] [clinical-trial-parse-server-takeda](https://github.com/biosensics/clinical-trial-parse-server-takeda)
+- [ ] [clinical-trial-parse-server-wheelchair](https://github.com/biosensics/clinical-trial-parse-server-wheelchair)
+- [ ] [clinical-trial-parse-server-tele-exergaming](https://github.com/biosensics/clinical-trial-parse-server-tele-exergaming)
+- [ ] [clinical-trial-parse-server-crp](https://github.com/biosensics/clinical-trial-parse-server-crp)
+- [ ] [clinical-trial-parse-server-tai-chi](https://bitbucket.org/biosensics/clinical-trial-parse-server-tai-chi/)
+- [ ] [clinical-trial-parse-server-stroke](https://github.com/biosensics/clinical-trial-parse-server-stroke)
+- [ ] [clinical-trial-parse-server-iadlsys](https://github.com/biosensics/clinical-trial-parse-server-iadlsys)
+
+If new parse servers are created please make a PR to put the server at the top of the list in the template issue.

--- a/.github/ISSUE_TEMPLATE/server-template-update.md
+++ b/.github/ISSUE_TEMPLATE/server-template-update.md
@@ -1,12 +1,14 @@
 ---
 name: Server Template Update
 about: A checklist of servers to consider this update for
-title: Server Template Update
+title:  Server Template Update for PR --
 labels: cherry-pick
 assignees: ''
 ---
 ---
-Please create an issue for every bugfix / feature update to the clinical-trial-parse-server-template repository and fill out below.
+Please create an issue for every bugfix / feature update to the clinical-trial-parse-server-template repository.
+
+Update the issue title with the PR number then, fill out below.
 
 ---
 


### PR DESCRIPTION
I made this issue template for https://github.com/biosensics/clinical-trial-parse-server-template as an easier way to keep track of what servers need what updates and which ones got them. Not all of them need to be checked off every time and the list will grow as more projects that run on our parse servers are created.