### PR TITLE
mason groups and projects template

### DIFF
--- a/workflow-templates/mason-project-group.yml
+++ b/workflow-templates/mason-project-group.yml
@@ -1,0 +1,55 @@
+name: New Mason Project & Group
+description: Create a new Mason project and group
+title: "[MASON]: "
+labels: ["mason"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Create the new projects and group for project [project-name]
+
+        A member of @biosensics/engineering may follow [BS-03-0048](https://biosenics.greenlight.guru/documents/6b42b337-2f77-4c43-b784-ef856b9b4131/effective-doc) to make the Mason groups/projects.
+
+        ## Project Creation
+        Must match the application id, replacing underscores for hyphens. Then a hyphen followed by the instance of the project.
+        For example:
+        Raw Project Name: `BioDigit-MG`
+        Application ID: `.biodigit_mg`
+        Test Project: `BioDigit-MG-TEST`
+        Production Project: `BioDigit-MG`
+  - type: checkboxes
+    attributes:
+      label: Create the projects for
+      description: Please select all instaces of the project to create
+      options:
+      - label: TEST
+        required: false
+      - label: UAT
+        required: false
+      - label: PRODUCTION
+        required: false
+  - type: markdown
+    attributes:
+      value: |
+        ## Group Creation 
+        See the work instruction, on 5.4
+  - type: checkboxes
+    attributes:
+      label: Create the groups for
+      description: Please select all instaces of the project to create
+      options:
+      - label: develop
+        required: false
+      - label: v-and-v
+        required: false
+      - label: uat
+        required: false
+      - label: production
+        required: false
+  - type: markdown
+    attributes:
+      value: |
+        ### Completion Checklist
+        - [ ] Project Created
+        - [ ] Groups Created
+        - [ ] Project build configs deployed, to the appropriate groups


### PR DESCRIPTION
Make an issue template so engineers may correctly make the correct mason groups and projects, and have it be tracked.